### PR TITLE
add the x509 certificate from the Crypki server also to the Key info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 
 ### IntelliJ IDEA ###
 .idea/
+.run
 
 ### Eclipse ###
 .apt_generated

--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,11 @@ Get all keys
 curl -X GET https://localhost:4443/v3/sig/blob/keys
 ```
 
+Get public x509 certificate
+```
+curl -X GET https://localhost:4443/v3/sig/x509-cert/keys/x509-key
+```
+
 Get public key
 ```
 curl -X GET https://localhost:4443/v3/sig/blob/keys/sign-blob-key

--- a/src/main/java/de/denniskniep/keycloak/hsm/crypki/service/BlobCertResponse.java
+++ b/src/main/java/de/denniskniep/keycloak/hsm/crypki/service/BlobCertResponse.java
@@ -1,0 +1,14 @@
+package de.denniskniep.keycloak.hsm.crypki.service;
+
+public class BlobCertResponse {
+
+    private String cert;
+
+    public String getCert() {
+        return cert;
+    }
+
+    public void setCert(String cert) {
+        this.cert = cert;
+    }
+}

--- a/src/main/java/de/denniskniep/keycloak/hsm/crypki/service/CrypkeyService.java
+++ b/src/main/java/de/denniskniep/keycloak/hsm/crypki/service/CrypkeyService.java
@@ -22,6 +22,11 @@ public class CrypkeyService implements Closeable {
         return blobKey.getKey();
     }
 
+    public String getX509Certificate() throws IOException {
+        BlobCertResponse cert = httpClient.get("/v3/sig/x509-cert/keys/x509-key", BlobCertResponse.class);
+        return cert.getCert();
+    }
+
     public  byte[] sign(String keyName, String hashAlgorithm, byte[] bytes) throws IOException {
         byte[] encoded = Base64.getEncoder().encode(bytes);
         BlobKeySigningRequest request = new BlobKeySigningRequest();


### PR DESCRIPTION
This is required, otherwise Keycloak can't build up the JWKS document which allows clients to validate the token signature signed with this key.

To get this working in a performant way, I also refactored the service and provider classes a bit (only create the service once for the lifetime of the class, not explicitly for each request) and replaced creation of PublicKey with Keycloak util methods already available.